### PR TITLE
Add bower package to project

### DIFF
--- a/blueprints/ember-sweetalert/index.js
+++ b/blueprints/ember-sweetalert/index.js
@@ -1,5 +1,7 @@
 module.exports = {
   normalizeEntityName: function() {},
 
-  afterInstall: function() {}
+  afterInstall: function() {
+    return this.addBowerPackageToProject('sweetalert2', '^6.1.0');
+  }
 };


### PR DESCRIPTION
Believe this will fix issue #3, plus is desired behaviour anyway because you need the installing Ember project to have sweetalert2 installed via bower.